### PR TITLE
Copper Golems prefer to complete stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # GolemForgetMeNot
 Lets Copper Golems inspect more storage containers before cooldown.
 By default increased from 10 to 24<br>
+
+Lets Copper Golems insert items preferably by completing existing stacks before inserting them into empty slots.
+By default true<br>
+
 Customizable using the golem_forget_me_not.json

--- a/src/main/java/com/aarocket/golemforgetmenot/GolemForgetMeNotConfig.java
+++ b/src/main/java/com/aarocket/golemforgetmenot/GolemForgetMeNotConfig.java
@@ -2,6 +2,7 @@ package com.aarocket.golemforgetmenot;
 
 public class GolemForgetMeNotConfig {
     private static int visitsUntilCooldown = 24;
+    private static boolean completeStacks = true;
 
     public static int getVisitsUntilCooldown() {
         return visitsUntilCooldown;
@@ -10,4 +11,13 @@ public class GolemForgetMeNotConfig {
     public static void setVisitsUntilCooldown(int value) {
         visitsUntilCooldown = value;
     }
+
+    public static boolean getCompleteStacks() {
+        return completeStacks;
+    }
+
+    public static void setCompleteStacks(boolean value) {
+        completeStacks = value;
+    }
+
 }

--- a/src/main/java/com/aarocket/golemforgetmenot/GolemForgetmeNotConfigLoader.java
+++ b/src/main/java/com/aarocket/golemforgetmenot/GolemForgetmeNotConfigLoader.java
@@ -24,9 +24,12 @@ public class GolemForgetmeNotConfigLoader {
             if (json.has("visitsUntilCooldown")) {
                 GolemForgetMeNotConfig.setVisitsUntilCooldown(json.get("visitsUntilCooldown").getAsInt());
             }
+            if (json.has("completeStacks")) {
+                GolemForgetMeNotConfig.setCompleteStacks(json.get("completeStacks").getAsBoolean());
+            }
             GolemForgetMeNot.LOGGER.info("Golem memory loaded!");
         } catch (IOException e) {
-            GolemForgetMeNot.LOGGER.error("Failed to load golem_forget_me_not.json... using default (24)", e);
+            GolemForgetMeNot.LOGGER.error("Failed to load golem_forget_me_not.json... using defaults (24, true)", e);
         }
     }
 
@@ -36,6 +39,7 @@ public class GolemForgetmeNotConfigLoader {
             CONFIG_FILE.getParentFile().mkdirs();
             JsonObject json = new JsonObject();
             json.addProperty("visitsUntilCooldown", GolemForgetMeNotConfig.getVisitsUntilCooldown());
+            json.addProperty("completeStacks", GolemForgetMeNotConfig.getCompleteStacks());
 
             try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
                 GSON.toJson(json, writer);

--- a/src/main/java/com/aarocket/golemforgetmenot/mixin/GolemMoveItemsMixin.java
+++ b/src/main/java/com/aarocket/golemforgetmenot/mixin/GolemMoveItemsMixin.java
@@ -1,10 +1,21 @@
 package com.aarocket.golemforgetmenot.mixin;
 
 import com.aarocket.golemforgetmenot.GolemForgetMeNotConfig;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
 import net.minecraft.entity.ai.brain.task.MoveItemsTask;
+import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Iterator;
 
 @Mixin(MoveItemsTask.class)
 public class GolemMoveItemsMixin {
@@ -16,4 +27,38 @@ public class GolemMoveItemsMixin {
 	private int modifyVisits(int original) {
 		return GolemForgetMeNotConfig.getVisitsUntilCooldown();
 	}
+
+	// if configuration asks for it, ignore empty slots during first pass of insertion, focussing on completing existing stacks first
+    @ModifyExpressionValue(
+        method = "insertStack(Lnet/minecraft/entity/mob/PathAwareEntity;Lnet/minecraft/inventory/Inventory;)Lnet/minecraft/item/ItemStack;",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z", ordinal = 0)
+    )
+    private static boolean modifyEmptyCheck(boolean original) {
+        // Only treat it as empty if we're NOT in complete-stacks mode
+        return original && !GolemForgetMeNotConfig.getCompleteStacks();
+    }
+	
+	// if configuration asks for it, only insert in empty slots after trying to complete existing stacks
+    @Inject(
+        method = "insertStack(Lnet/minecraft/entity/mob/PathAwareEntity;Lnet/minecraft/inventory/Inventory;)Lnet/minecraft/item/ItemStack;",
+        at = @At("RETURN"),
+        cancellable = true
+    )
+    private static void addSecondPass(PathAwareEntity entity, Inventory inventory, CallbackInfoReturnable<ItemStack> cir) {
+        if (!GolemForgetMeNotConfig.getCompleteStacks()) return;
+        ItemStack itemStack = cir.getReturnValue();
+        if (itemStack.isEmpty()) return;
+        int i = 0;
+        for (Iterator<ItemStack> it = inventory.iterator(); it.hasNext(); ++i) {
+            ItemStack itemStack2 = it.next();
+            if (itemStack2.isEmpty()) {
+                inventory.setStack(i, itemStack);
+                cir.setReturnValue(ItemStack.EMPTY);
+                return;
+            }
+        }
+        // If we reach here, itemStack still not inserted, return it as-is
+        cir.setReturnValue(itemStack);
+    }
+
 }


### PR DESCRIPTION
Lets Copper Golems insert items preferably by completing existing stacks before inserting them into empty slots.
As per suggestion #1.